### PR TITLE
Remove Index older then genome bedtools error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setuptools.setup(
             "check-manifest",
             "docutils",
             "flake8",
-            "isort",
+            "isort<5.0.0",
             "ngs-test-utils",
             "pydocstyle",
             "pytest-cov",

--- a/src/imaps/sandbox/kmers.py
+++ b/src/imaps/sandbox/kmers.py
@@ -949,10 +949,12 @@ def run(
             reference.saveas(f"./results/{sample_name}_oxn_{region}.bed")
         # get sequences around all crosslinks not in peaks
         reference_sequences = get_sequences(
-            reference, genome, genome_fai, window + kmer_length, window + kmer_length, merge_overlaps=False
+            reference, genome, genome_chr_sizes, window + kmer_length, window + kmer_length, merge_overlaps=False
         )
         # get sequences around all thresholded crosslinks
-        sequences = get_sequences(sites, genome, genome_fai, window_distal + kmer_length, window_distal + kmer_length)
+        sequences = get_sequences(
+            sites, genome, genome_chr_sizes, window_distal + kmer_length, window_distal + kmer_length
+        )
         if repeats == "unmasked":
             sequences = [s.upper() for s in sequences]
         get_sequences_cp = time.time()


### PR DESCRIPTION
Bedtools throw an error is the .fai file looks older then the .fasta file and this fix aim at preventing the error by making a fresh file to be used as .fai