### PR TITLE
updates - prtxn positions, saving K-mer rtxn values into tsv file, intersecting thresholded crosslinks with peak file

### DIFF
--- a/src/imaps/sandbox/kmers.py
+++ b/src/imaps/sandbox/kmers.py
@@ -891,8 +891,6 @@ def run(
     - top_n: number of kmers ranked by z-score in descending order for
       clustering and plotting (default 20)
     - percentile: used for thresholding crosslinks (default 0.7)
-    - min_relative_occurence: ratio of kmer distribution around (thresholded)
-      crosslinks to distal occurrences (default 2)
     - clusters: number of clusters of kmers(default 5)
     - smoothing: window used for smoothing kmer positional distribution curves
     (default 6)
@@ -1142,7 +1140,6 @@ def run(
         top_kmers = kmers_order_of_enrichment[:top_n]
         # normalize kmer occurences by number of thresholded crosslinks for
         # easier comparison across different samples
-        ntxn = len(sites)
         kmer_occ_per_txl = {x: {} for x in kmer_pos_count}
         for motif, pos_m in kmer_pos_count.items():
             for pos, count in pos_m.items():

--- a/src/imaps/sandbox/kmers.py
+++ b/src/imaps/sandbox/kmers.py
@@ -535,18 +535,6 @@ def get_top_n_kmers(kmer_count, num):
     return [item[0] for item in sorted(kmer_count.items(), key=lambda x: x[1], reverse=True)[:num]]
 
 
-def most_frequent(lst):
-    """Finds the most frequent prtxn."""
-    dict_counts = {}
-    lst = [x for x in lst if str(x)!='nan']
-    el_count = 0
-    for el in list(set(lst)):
-        if lst.count(el) > el_count:
-            el_count = lst.count(el)
-            element = el
-    return element
-
-
 @ignore_warnings(category=ConvergenceWarning)
 def get_clustering(kmer_pos_count, x1, x2, kmer_length, window, smoot, n_clusters):
     """Smoothen positional data for each kmer and then cluster kmers.
@@ -1072,12 +1060,10 @@ def run(
                         all_prtxns.append(pos)
                 except KeyError:
                     pass
-        #Find the most common prtxn position.
-        prtxn_most_common = most_frequent(all_prtxns)
-        #Assign the most common prtxn to kmers with empty prtxn list
+        #Assign the max_p to kmers with empty prtxn list
         for i, val in prtxn.items():
             if len(val) == 0:
-                val.append(prtxn_most_common)
+                val.append(max_p[i])
 
         random_aroxn = []
         for roxn_sample in random_roxn:


### PR DESCRIPTION
The following changes were introduced:
- where the list of prtxn positions is empty, max peak position is assigned as prtxn position, 
- an additional table with rtxn values is saved, 
- only thresholded crosslinks within the peak files are used
- a new option allows using other peak files to intersect thresholded crosslinks with.